### PR TITLE
Parse laps and segments of ExerciseSessionRecord 

### DIFF
--- a/lib/src/records/exercise_lap.dart
+++ b/lib/src/records/exercise_lap.dart
@@ -44,7 +44,7 @@ class ExerciseLap {
       startTime: DateTime.parse(map['startTime']),
       endTime: DateTime.parse(map['endTime']),
       length: map['length'] != null
-          ? Length.fromMap(Map<String, dynamic>.from(map['distance']))
+          ? Length.fromMap(Map<String, dynamic>.from(map['length']))
           : null,
     );
   }

--- a/lib/src/records/exercise_session_record.dart
+++ b/lib/src/records/exercise_session_record.dart
@@ -128,10 +128,14 @@ class ExerciseSessionRecord extends IntervalRecord {
       exerciseType: ExerciseType.fromValue(map['exerciseType']),
       title: map['title'],
       notes: map['notes'],
-      segments: List<ExerciseSegment>.from(
-          map['segments']?.map((x) => ExerciseSegment.fromMap(x))),
-      laps: List<ExerciseLap>.from(
-          map['laps']?.map((x) => ExerciseLap.fromMap(x))),
+      segments: map['segments'] != null
+          ? List<ExerciseSegment>.from(map['segments'].map(
+              (x) => ExerciseSegment.fromMap(Map<String, dynamic>.from(x))))
+          : [],
+      laps: map['laps'] != null
+          ? List<ExerciseLap>.from(map['laps']
+              .map((x) => ExerciseLap.fromMap(Map<String, dynamic>.from(x))))
+          : [],
       route: map['route'] != null
           ? ExerciseRoute.fromMap(Map<String, dynamic>.from(map['route']))
           : null,


### PR DESCRIPTION
Explicit casting is required for the `from` to work without exceptions like this:
```
_TypeError: type '_Map<Object?, Object?>' is not a subtype of type 'Map<String, dynamic>'
I/flutter (23093): #0      new ExerciseSessionRecord.fromMap.
```